### PR TITLE
Fix typos and refactor

### DIFF
--- a/generate-client-certs.sh
+++ b/generate-client-certs.sh
@@ -4,24 +4,27 @@
 # - $1 - Path to ca.pem
 # - $2 - Path to ca-key.pem
 
-if [ "$1" == "" ] || [ "$2" == ""]; then
+if [ "$1" = "" ] || [ "$2" = "" ]; then
     echo "Please provide paths to the ca.pem and ca-key.pem files."
-    exit
+    exit 2
 fi
 
 echo 01 > ca.srl
-cp $1 ca.pem
-cp $2 ca-key.pem
+cp "$1" ca.pem
+cp "$2" ca-key.pem
 
 openssl genrsa -out client-key.pem
 openssl req -new -key client-key.pem -out client.csr
 
-echo extendedKeyUsage = clientAuth > extfile.cnf
-openssl x509 -req -days 365 -in client.csr -CA ca.pem -CAkey ca-key.pem -out client-cert.pem -extfile extfile.cnf
+echo 'extendedKeyUsage = clientAuth' > extfile.cnf
+
+openssl x509 -req -days 365 \
+    -in client.csr \
+    -out client-cert.pem \
+    -CA ca.pem \
+    -CAkey ca-key.pem \
+    -extfile extfile.cnf
 
 # Cleanup
-rm ca.srl
-rm ca.pem
-rm ca-key.pem
-rm client.csr
-rm extfile.cnf
+rm ca.srl ca.pem ca-key.pem client.csr extfile.cnf
+


### PR DESCRIPTION
1. add mandatory whitespace before the closing test bracket
2. add double-quotes around argument expansions
3. refactor